### PR TITLE
don't clobber xml.validation.enable setting in EPPWriter

### DIFF
--- a/src/main/java/com/ausregistry/jtoolkit2/xml/EPPWriter.java
+++ b/src/main/java/com/ausregistry/jtoolkit2/xml/EPPWriter.java
@@ -28,7 +28,6 @@ public class EPPWriter extends XMLWriter {
         SAX_PARSER_FACTORY = SAXParserFactory.newInstance();
         SAX_PARSER_FACTORY.setNamespaceAware(true);
         SAX_PARSER_FACTORY.setValidating(false);
-        EPPSchemaProvider.setValidating(true);
         SAX_PARSER_FACTORY.setSchema(EPPSchemaProvider.getSchema());
     }
 


### PR DESCRIPTION
EPPWriter had a static initializer that turned on XML validation
regardless of if it was disabled in the session manager properties.

Fixes #3