### PR TITLE
fix broken CommandFailedExceptions

### DIFF
--- a/src/main/java/com/ausregistry/jtoolkit2/session/SessionManagerImpl.java
+++ b/src/main/java/com/ausregistry/jtoolkit2/session/SessionManagerImpl.java
@@ -393,8 +393,8 @@ public class SessionManagerImpl implements SessionManager {
                         case ResultCode.CMD_FAILED:
                             throw new CommandFailedException();
                         case ResultCode.CMD_FAILED_CLOSING:
-                        default:
                             throw new CommandFailedException();
+                        default:
                         }
                     }
                 }


### PR DESCRIPTION
This PR fixes the checking of EPP Result codes in responses.

This was broken in 725bc4755bad4f253c49298ea0102fdbaba0e077 which inserted a "default" into the switch (code) block that did:

    default:
        throw new CommandFailedException();

This is clearly wrong and means that CommandFailedException() is thrown for EVERY SINGLE RESPONSE that is handled by execute().

Fixed by moving the default clause to the end with no action, which is how it should have been all along.