### PR TITLE
Added Null check to avoid NullPointerException

### DIFF
--- a/src/main/java/com/ausregistry/jtoolkit2/se/Result.java
+++ b/src/main/java/com/ausregistry/jtoolkit2/se/Result.java
@@ -143,7 +143,7 @@ public class Result implements java.io.Serializable {
      * Return the text content of the resultValue element at the specified index.
      */
     public String getResultExtReason(int nodeIndex) {
-        if (nodeIndex > resultExtvalueReasons.length) {
+        if (resultExtvalueReasons == null || nodeIndex > resultExtvalueReasons.length) {
             return null;
         }
 


### PR DESCRIPTION
When login command returns 2400 response code with no Ext Reason, raiseLoginException(result.hasResultExtReasons(), result.getResultExtReason(0)); in TLSSession causes NullPointerException.